### PR TITLE
Add unit tests for compression utilities

### DIFF
--- a/tests/test_llm_code_explainer.py
+++ b/tests/test_llm_code_explainer.py
@@ -1,0 +1,35 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import builtins
+import types
+from unittest import mock
+import pytest
+
+import llm_code_explainer as explainer
+
+
+def test_count_tokens_basic():
+    text = "print('hello world')"
+    expected = len(explainer.nlp(text))
+    assert explainer.count_tokens(text) == expected
+
+
+def test_get_code_explanation_returns_text():
+    fake_resp = types.SimpleNamespace(choices=[types.SimpleNamespace(text=" explanation ")])
+    with mock.patch.object(explainer, "OpenAI") as mock_openai:
+        instance = mock_openai.return_value
+        instance.completions.create.return_value = fake_resp
+        result = explainer.get_code_explanation("print('hi')")
+        assert result == "explanation"
+        instance.completions.create.assert_called_once()
+
+
+def test_main_exits_without_repo_url(tmp_path):
+    repo_path = tmp_path / "does_not_exist"
+    args = ["prog", "--repo_path", str(repo_path), "--output_base_path", str(tmp_path / "out")]
+    with mock.patch.object(builtins, "print") as mock_print:
+        with mock.patch.object(sys, "argv", args):
+            with mock.patch.object(explainer, "sys", sys):
+                with pytest.raises(SystemExit):
+                    explainer.main()
+    mock_print.assert_called()

--- a/tests/test_llm_codebase_compressor.py
+++ b/tests/test_llm_codebase_compressor.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import types
+from unittest import mock
+import tiktoken
+
+import llm_codebase_compressor as cc
+
+
+def test_clone_repo_if_needed_local():
+    path = '/tmp/repo'
+    assert cc.clone_repo_if_needed(path) == path
+
+
+def test_clone_repo_if_needed_url(monkeypatch, tmp_path):
+    dummy_dir = tmp_path / 'clone'
+    monkeypatch.setattr(cc.tempfile, 'mkdtemp', lambda: str(dummy_dir))
+    with mock.patch.object(cc.git.Repo, 'clone_from') as clone:
+        result = cc.clone_repo_if_needed('https://example.com/repo.git')
+        clone.assert_called_once_with('https://example.com/repo.git', str(dummy_dir))
+        assert result == str(dummy_dir)
+
+
+def test_gather_python_files_exclude(tmp_path):
+    (tmp_path / 'a.py').write_text('print(1)')
+    (tmp_path / 'b.txt').write_text('hi')
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'c.py').write_text('print(2)')
+    files = cc.gather_python_files(str(tmp_path), ['sub/*'])
+    assert os.path.join(str(tmp_path), 'a.py') in files
+    assert all('sub' not in f for f in files)
+
+
+def test_build_simple_call_graph(tmp_path):
+    code = 'def foo():\n    bar()\n\ndef bar():\n    pass\n'
+    file_path = tmp_path / 'code.py'
+    file_path.write_text(code)
+    graph = cc.build_simple_call_graph(str(file_path))
+    assert graph['foo'] == ['bar']
+    assert 'bar' in graph
+
+
+def test_count_tokens():
+    enc = tiktoken.get_encoding('cl100k_base')
+    assert cc.count_tokens('hello', enc) == len(enc.encode('hello'))
+
+
+def test_summarise_file_mock_openai():
+    fake_resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='sum'))])
+    with mock.patch.object(cc, 'OpenAI') as mock_openai:
+        instance = mock_openai.return_value
+        instance.chat.completions.create.return_value = fake_resp
+        out = cc.summarise_file('code', {}, 'auto_detect', 'gpt-4o-mini')
+        assert out == 'sum'
+        instance.chat.completions.create.assert_called_once()
+
+
+def test_compress_repository_integration(tmp_path, monkeypatch):
+    f1 = tmp_path / 'a.py'
+    f1.write_text('def a():\n    pass')
+    f2 = tmp_path / 'b.py'
+    f2.write_text('def b():\n    pass')
+    monkeypatch.setattr(cc, 'summarise_file', lambda code, graph, mode, model: 'summary')
+    result = cc.compress_repository(str(tmp_path), 1000, 'auto_detect', 'gpt-4o-mini', 'markdown', False, [])
+    assert 'a.py' in result and 'b.py' in result

--- a/tests/test_llm_text_compressor.py
+++ b/tests/test_llm_text_compressor.py
@@ -1,0 +1,47 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from unittest import mock
+import types
+import tiktoken
+import pytest
+
+import llm_text_compressor as tc
+
+
+def test_calculate_prompt_tokens():
+    encoding = tiktoken.get_encoding('cl100k_base')
+    system_message = 'sys'
+    prompts = {'a': 'hello {target_word_count} {chunk_string}'}
+    # Build expected using same formula
+    expected = len(encoding.encode(system_message + prompts['a'].format(target_word_count=0, chunk_string="")))
+    assert tc.calculate_prompt_tokens(system_message, prompts, encoding) == expected
+
+
+def test_split_text_into_chunks_simple():
+    encoding = tiktoken.get_encoding('cl100k_base')
+    text = 'a b c d'
+    chunks, counts = tc.split_text_into_chunks(text, 2, encoding)
+    assert chunks and counts
+    assert sum(counts) == len(encoding.encode(text))
+    assert all(c <= 2 for c in counts)
+
+
+def test_get_prompts_json_flag():
+    system_message, prompts = tc.get_prompts(True)
+    assert 'format the output as JSON' in prompts['auto_detect']
+    assert isinstance(system_message, str)
+
+
+def test_compute_target_word_count_per_chunk():
+    result = tc.compute_target_word_count_per_chunk(50, 100, 60, 2)
+    assert result == max(int(((0.5*60)/2)/1.3), 1)
+
+
+def test_compress_chunk_uses_openai():
+    fake_resp = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='short'))])
+    with mock.patch.object(tc, 'OpenAI') as mock_openai:
+        instance = mock_openai.return_value
+        instance.chat.completions.create.return_value = fake_resp
+        out = tc.compress_chunk('txt', 'auto_detect', 10, {'auto_detect': 'hey {target_word_count} {chunk_string}'}, False, 'sys', 'model')
+        assert out == 'short'
+        instance.chat.completions.create.assert_called_once()


### PR DESCRIPTION
## Summary
- add pytest suites for `llm_code_explainer`, `llm_text_compressor`, and `llm_codebase_compressor`
- mock OpenAI interactions and repository cloning
- cover helper functions like token counting, chunking and compression helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840044f0ec08321b890df4935aa2dff